### PR TITLE
Fix array_merge PHP warnings and greyed out select menu options

### DIFF
--- a/acf-taxonomy-chooser-v5.php
+++ b/acf-taxonomy-chooser-v5.php
@@ -186,7 +186,12 @@ class acf_field_taxonomy_chooser extends acf_field {
 
        	if( $field['tax_type'] == 'Term' ){ // select terms
        		 foreach( $slug_name as $k1 => $v1 ) {
-	        	$terms = array_merge($terms, get_terms( $v1, array( 'hide_empty' => false ) ) );
+		
+	            $found_terms = get_terms( $v1, array( 'hide_empty' => false ));
+		    if (!empty($found_terms) && is_array($found_terms)) {
+			$terms = array_merge($terms, $found_terms);
+		    }
+			 
 	            foreach( $taxonomies as $k2 => $v2 ) {
 	                if( $v1 == $k2 ) {
 	                    $slug_name[$k1] = $v2;
@@ -376,7 +381,6 @@ class acf_field_taxonomy_chooser extends acf_field {
         	                $el['selected'] = 'selected';
 
          	           }
-        	            echo acf_esc_attr( $el );
         	            echo '<option ' . acf_esc_attr( $el ) . '>' . $label . '</option>';
 
         	        } else {


### PR DESCRIPTION
Check that get_terms result is an array before trying to use it in merge_array. Also removed the same line from incredimike's open pull request.